### PR TITLE
Feature/issue 3

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,4 +2,5 @@ Add /version.jsp path for checking version
 Decrease log level for rules
 Fix perseo-core.properties for reference missing from WAR file (#19)
 Fix Use service/subservice (#21)
+Fix Use UTF-8 in responses (#3)
 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,5 +2,5 @@ Add /version.jsp path for checking version
 Decrease log level for rules
 Fix perseo-core.properties for reference missing from WAR file (#19)
 Fix Use service/subservice (#21)
-Fix Use UTF-8 in responses (#3)
+Fix Use UTF-8 in responses and default encoding for request (#3)
 

--- a/src/main/java/com/telefonica/iot/perseo/EventsServlet.java
+++ b/src/main/java/com/telefonica/iot/perseo/EventsServlet.java
@@ -79,9 +79,10 @@ public class EventsServlet extends HttpServlet {
             throws ServletException, IOException {
         Utils.putCorrelatorAndTrans(request);
         logger.debug("events doPost");
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json;charset=UTF-8");
         PrintWriter out = response.getWriter();
         try {
-            response.setContentType("application/json;charset=UTF-8");
             StringBuilder sb = new StringBuilder();
             String eventText = Utils.getBodyAsString(request);
             logger.info("incoming event:" + eventText);

--- a/src/main/java/com/telefonica/iot/perseo/RulesServlet.java
+++ b/src/main/java/com/telefonica/iot/perseo/RulesServlet.java
@@ -73,8 +73,9 @@ public class RulesServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         Utils.putCorrelatorAndTrans(request);
-        PrintWriter out = response.getWriter();
+        response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json;charset=UTF-8");
+        PrintWriter out = response.getWriter();
         logger.info("get rule " + request.getPathInfo());
         String ruleName = request.getPathInfo();
         //request.getPathInfo() returns null or the extra path information
@@ -100,8 +101,9 @@ public class RulesServlet extends HttpServlet {
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         Utils.putCorrelatorAndTrans(request);
-        PrintWriter out = response.getWriter();
+        response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json;charset=UTF-8");
+        PrintWriter out = response.getWriter();
         String body = Utils.getBodyAsString(request);
         Result r = RulesManager.make(epService, body);
         response.setStatus(r.getStatusCode());
@@ -121,8 +123,9 @@ public class RulesServlet extends HttpServlet {
     protected void doPut(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         Utils.putCorrelatorAndTrans(request);
-        PrintWriter out = response.getWriter();
+        response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json;charset=UTF-8");
+        PrintWriter out = response.getWriter();
         String body = Utils.getBodyAsString(request);
         Result r = RulesManager.updateAll(epService, body);
         response.setStatus(r.getStatusCode());
@@ -142,8 +145,9 @@ public class RulesServlet extends HttpServlet {
     protected void doDelete(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         Utils.putCorrelatorAndTrans(request);
-        PrintWriter out = response.getWriter();
+        response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json;charset=UTF-8");
+        PrintWriter out = response.getWriter();
         logger.info("delete rule " + request.getPathInfo());
         String ruleName = request.getPathInfo();
         Result r = RulesManager.delete(epService, ruleName.substring(1));

--- a/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -1,23 +1,24 @@
 /**
-* Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
-*
+ * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ * 
 * This file is part of perseo-core project.
-*
-* perseo-core is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
-* General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
-* option) any later version.
-*
-* perseo-core is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
-* implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
-* for more details.
-*
-* You should have received a copy of the GNU Affero General Public License along with perseo-core. If not, see
-* http://www.gnu.org/licenses/.
-*
-* For those usages not covered by the GNU Affero General Public License please contact with
-* iot_support at tid dot es
-*/
-
+ * 
+* perseo-core is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ * 
+* perseo-core is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ * 
+* You should have received a copy of the GNU Affero General Public License
+ * along with perseo-core. If not, see http://www.gnu.org/licenses/.
+ * 
+* For those usages not covered by the GNU Affero General Public License please
+ * contact with iot_support at tid dot es
+ */
 package com.telefonica.iot.perseo;
 
 import com.espertech.esper.client.ConfigurationOperations;
@@ -210,7 +211,7 @@ public class Utils {
             return false;
         }
     }
-    
+
     /**
      * Capture correlator and generate
      *
@@ -226,6 +227,7 @@ public class Utils {
         MDC.put(Constants.TRANSACTION_ID, transId);
         MDC.put(Constants.CORRELATOR_ID, correlatorId);
     }
+
     /**
      * Return body as a String
      *
@@ -235,6 +237,10 @@ public class Utils {
      *
      */
     public static String getBodyAsString(HttpServletRequest request) throws IOException {
+        logger.debug("request.getCharacterEncoding() " + request.getCharacterEncoding());
+        if (request.getCharacterEncoding() == null) {
+            request.setCharacterEncoding("UTF-8");
+        }
         StringBuilder sb = new StringBuilder();
         BufferedReader br = request.getReader();
         String read = br.readLine();


### PR DESCRIPTION
Use UTF-8 as encoding for response
Set UTF-8 as default encoding for request

Fix issue #3 

//These requests/responses are "internal", perseo-fe<=>perseo-core. External clients should not be affected

@fgalan 
@jcalderin 
