### PR TITLE
Upgrade Esper library from 4.7.0 to 5.5.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Upgrade Esper library from 4.7.0 to 5.5.0

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper</artifactId>
-            <version>4.7.0</version>
+            <version>5.5.0</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
Addresses issue #87 

`mvn package` is ok
`mvn test` is ok with the following result:

``` 
Results :

Tests run: 20, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 34.895s
[INFO] Finished at: Wed Dec 13 15:51:21 CET 2017
[INFO] Final Memory: 14M/178M
[INFO] ------------------------------------------------------------------------
```