### PR TITLE
Initial set-up for ReadtheDocs documentation for Perseo Core.

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,0 +1,5 @@
+# Perseo-core (EPL server)
+
+[![FIWARE Processing](https://nexus.lab.fiware.org/static/badges/chapters/processing.svg)](https://www.fiware.org/developers/catalogue/)
+[![](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/fiware.svg)](https://stackoverflow.com/questions/tagged/fiware)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Perseo Core
 site_url: https://fiware-perseo-core.readthedocs.org
-repo_url: https://github.com/telefonicaid/perseo-dore.git
+repo_url: https://github.com/telefonicaid/perseo-core.git
 site_description: Perseo Core (EPL server)
 docs_dir: documentation
 site_dir: html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: Perseo Core
+site_url: https://fiware-perseo-core.readthedocs.org
+repo_url: https://github.com/telefonicaid/perseo-dore.git
+site_description: Perseo Core (EPL server)
+docs_dir: documentation
+site_dir: html
+markdown_extensions: [toc,fenced_code]
+use_directory_urls: false
+theme: readthedocs
+extra_css: ["https://fiware.org/style/fiware_readthedocs.css", "https://www.fiware.org/style/fiware_readthedocs_processing.css"]
+
+pages:
+  - 'Home': 'index.md' 
+  - 'Architecture': 'architecture.md'
+  - 'Installation & Administration Manual':
+    - 'Admin': 'admin.md'
+    - 'Deployment': 'deployment.md'
+    - 'Configuration': 'config.md'
+    - 'Logs': 'logs.md'
+  - 'User Guide':
+      - 'Introduction': 'api.md'


### PR DESCRIPTION
- Please create a project on readthedocs called fiware-perseo-core and point to this repository.
- Includes standard CSS and badges.
- Just a dump of existing documentation but with CSS styling.