### PR TITLE
add utility for sunrise and sunset

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-Add library to retrieve sunset and sunrise (#130)
+Add library (lib-sunrise-sunset 1.1.1) to retrieve sunset and sunrise (#130)
 Upgrade Esper library from 6.1.0 to 7.1.0
 Fix use openjdk8 oficial instead unofficial openjdk after bug in official openjdk-8-jdk was fixed
 Fix perseo-core log in docker container (#110)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Add library to retrieve sunset and sunrise (#130)
 Upgrade Esper library from 6.1.0 to 7.1.0
 Fix use openjdk8 oficial instead unofficial openjdk after bug in official openjdk-8-jdk was fixed
 Fix perseo-core log in docker container (#110)

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,13 @@
         <sonar.dynamic>reuseReports</sonar.dynamic>
     </properties>
 
+    <repositories>
+      <repository>
+        <id>caarmen-repo</id>
+        <url>https://dl.bintray.com/caarmen/maven/</url>
+      </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -61,6 +68,12 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>
+        </dependency>
+        <dependency>
+          <groupId>ca.rmen</groupId>
+          <artifactId>lib-sunrise-sunset</artifactId>
+          <version>1.1.1</version>
+          <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -73,6 +73,10 @@ public class Utils {
             def.put(Constants.SERVICE_FIELD, String.class);
             ConfigurationOperations cfg = epService.getEPAdministrator().getConfiguration();
             cfg.addEventType(Constants.IOT_EVENT, def);
+
+            // Add SunriseSunset library
+            cfg.addImport("ca.rmen.sunrisesunset.*");
+
             sc.setAttribute(EPSERV_ATTR_NAME, epService);
         }
         return epService;


### PR DESCRIPTION
related to issue: https://github.com/telefonicaid/perseo-core/issues/130
-  [x] Tested with a select
- [x] Ensure that can be used in a timer with ```every timer:schedule(date: XXX)```

how to use it in a select:
```
select ca.rmen.sunrisesunset.SunriseSunset.getSunriseSunset(java.util.Calendar.getInstance(), 48.85837, 2.294481);
```

```
select ((ca.rmen.sunrisesunset.SunriseSunset.getSunriseSunset(java.util.Calendar.getInstance(), 48.85837, 2.294481)).get(0)).getTime() as Sunrise
```
```
select ((ca.rmen.sunrisesunset.SunriseSunset.getSunriseSunset(java.util.Calendar.getInstance(), 48.85837, 2.294481)).get(0)).getTimeInMillis() as Sunrise
```