### PR TITLE
Update to esper 7.1.0 in pom.xml

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+Upgrade Esper library from 6.1.0 to 7.1.0
 Fix perseo-core log in docker container (#110)

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper</artifactId>
-            <version>6.1.0</version>
+            <version>8.3.0</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper</artifactId>
-            <version>8.3.0</version>
+            <version>7.1.0</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
Latest version of esper is 8.3.0
Full changelog of esper: https://github.com/espertechinc/esper/blob/master/changelog.txt