### PR TITLE
add single function for getSunriseSunset

### DIFF
--- a/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -76,7 +76,7 @@ public class Utils {
 
             // Add SunriseSunset library
             cfg.addImport("ca.rmen.sunrisesunset.*");
-
+            cfg.addPlugInSingleRowFunction("getSunriseSunset", "ca.rmen.sunrisesunset.SunriseSunset", "getSunriseSunset");
             sc.setAttribute(EPSERV_ATTR_NAME, epService);
         }
         return epService;

--- a/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -25,6 +25,7 @@ import com.espertech.esper.client.EPServiceProvider;
 import com.espertech.esper.client.EPServiceProviderManager;
 import com.espertech.esper.client.EPStatement;
 import com.espertech.esper.client.EventBean;
+import com.espertech.esper.client.ConfigurationException;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -76,7 +77,14 @@ public class Utils {
 
             // Add SunriseSunset library
             cfg.addImport("ca.rmen.sunrisesunset.*");
-            cfg.addPlugInSingleRowFunction("getSunriseSunset", "ca.rmen.sunrisesunset.SunriseSunset", "getSunriseSunset");
+            // Add Single row function for getSunriseSunset
+            try {
+                cfg.addPlugInSingleRowFunction("getSunriseSunset",
+                                               "ca.rmen.sunrisesunset.SunriseSunset",
+                                               "getSunriseSunset");
+            } catch (ConfigurationException e) {
+                logger.error(e.getMessage());
+            }
             sc.setAttribute(EPSERV_ATTR_NAME, epService);
         }
         return epService;


### PR DESCRIPTION
- [x] Tested

in a EPL like

```
select current_timestamp().format("hh:mm:ss") as ts, 
((ca.rmen.sunrisesunset.SunriseSunset.getSunriseSunset(java.util.Calendar.getInstance(), 40.416775, -3.703790)).get(0)).getTime() as Sunrise, ((ca.rmen.sunrisesunset.SunriseSunset.getSunriseSunset(java.util.Calendar.getInstance(), 40.416775, -3.703790)).get(1)).getTime() as Sunset,
java.lang.String.valueOf(current_timestamp()) as tostring from pattern [every timer:schedule(repetitions: -1, date: java.util.Calendar.getInstance().getTime(),  period: 1 minute )]
```

use ```getSunriseSuntSet``` insteaad of ```ca.rmen.sunrisesunset.SunriseSunset.getSunriseSunset``` which is more legible