### PR TITLE
edited tests and add new functions

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,6 +2,6 @@ Project detached into maven modules.
 Perseo-core used as parent module.
 Refactorized perseo-core into perseo-main.
 Removed SunriseSunset library from perseo-main. Now is attached to perseo-utils.
-Add perseo-utils library import into Esper.
+Add perseo-utils library (date time utility functions) into Esper. 
 Disable cache from imported functions used as EPL.
 Disable cache on EPServiceProvider setup.

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -100,7 +100,12 @@ public class Utils {
                 cfg.addPlugInSingleRowFunction("timeToUTC",
                         "com.telefonica.iot.perseo.utils.DateTimeUtils",
                         "timeToUTC", ConfigurationPlugInSingleRowFunction.ValueCache.DISABLED);
-
+                cfg.addPlugInSingleRowFunction("getSecondsToNextSunset",
+                        "com.telefonica.iot.perseo.utils.DateTimeUtils",
+                        "getSecondsToNextSunset", ConfigurationPlugInSingleRowFunction.ValueCache.DISABLED);
+                cfg.addPlugInSingleRowFunction("getSecondsToNextSunrise",
+                        "com.telefonica.iot.perseo.utils.DateTimeUtils",
+                        "getSecondsToNextSunrise", ConfigurationPlugInSingleRowFunction.ValueCache.DISABLED);
             } catch (ConfigurationException e) {
                 logger.error(e.getMessage());
             }

--- a/perseo-utils/src/main/java/com/telefonica/iot/perseo/utils/DateTimeUtils.java
+++ b/perseo-utils/src/main/java/com/telefonica/iot/perseo/utils/DateTimeUtils.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The type Date time utils.
@@ -91,6 +92,44 @@ public class DateTimeUtils {
     public static long getMilisToNextSunrise(Calendar day, double latitude, double longitude) {
         Calendar sunriseSunrise = getNextSunrise(day, latitude, longitude);
         return (sunriseSunrise.getTimeInMillis() - day.getTimeInMillis());
+    }
+
+    /**
+     * Gets seconds to next sunset.
+     * It calculates next sunset considering provided date and time
+     * If date and time provided is older than sunset it adds +1 day to date and calculates again
+     * Finally, tunrns result into seconds
+     *
+     * @param day       the day Calendar object on ISO format
+     * @param latitude  the latitude
+     * @param longitude the longitude
+     * @return the seconds to next sunset
+     */
+    public static long getSecondsToNextSunset(Calendar day, double latitude, double longitude) {
+        long sunriseSunset = getMilisToNextSunset(day, latitude, longitude);
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(sunriseSunset);
+        if ((seconds*1000) < sunriseSunset)
+            seconds += 1;
+        return seconds;
+    }
+
+    /**
+     * Gets seconds to next sunrise.
+     * It calculates next sunrise considering provided date and time
+     * If date and time provided is older than sunrise it adds +1 day to date and calculates again
+     * Finally, tunrns result into seconds
+     *
+     * @param day       the day Calendar object on ISO format
+     * @param latitude  the latitude
+     * @param longitude the longitude
+     * @return the seconds to next sunrise
+     */
+    public static long getSecondsToNextSunrise(Calendar day, double latitude, double longitude) {
+        long sunriseSunset = getMilisToNextSunrise(day, latitude, longitude);
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(sunriseSunset);
+        if ((seconds*1000) < sunriseSunset)
+            seconds += 1;
+        return seconds;
     }
 
     /**

--- a/perseo-utils/src/test/java/com/telefonica/iot/perseo/utils/DateTimeUtilsTest.java
+++ b/perseo-utils/src/test/java/com/telefonica/iot/perseo/utils/DateTimeUtilsTest.java
@@ -36,6 +36,8 @@ public class DateTimeUtilsTest extends TestCase {
 
     public final long DAYTOMILIS = 86400000;
 
+    public final long SECONDTOMILIS = 1000;
+
     /**
      * Test get next sunrise.
      * Calculates next sunrise and compares it to current date.
@@ -82,6 +84,30 @@ public class DateTimeUtilsTest extends TestCase {
         Calendar calendar = Calendar.getInstance();
         long nextSunset = DateTimeUtils.getMilisToNextSunset(calendar, LATITUDE, LONGITUDE);
         assertTrue(nextSunset < DAYTOMILIS);
+    }
+
+    /**
+     * Test get milis to next sunrise
+     * Calculates milliseconds to next sunrise considering current date
+     * Is successful if the resoult is less than 24 hrs (86400000 milliseconds)
+     */
+    public void testGetSecondsToNextSunrise() {
+        System.out.println("getSecondsToNextSunrise");
+        Calendar calendar = Calendar.getInstance();
+        long nextSunrise = DateTimeUtils.getSecondsToNextSunrise(calendar, LATITUDE, LONGITUDE);
+        assertTrue(nextSunrise < (DAYTOMILIS + SECONDTOMILIS));
+    }
+
+    /**
+     * Test get milis to next sunset.
+     * Calculates milliseconds to next sunset considering current date
+     * Is successful if the resoult is less than 24 hrs (86400000 milliseconds)
+     */
+    public void testGetSecondsToNextSunset() {
+        System.out.println("getSecondsToNextSunset");
+        Calendar calendar = Calendar.getInstance();
+        long nextSunset = DateTimeUtils.getSecondsToNextSunset(calendar, LATITUDE, LONGITUDE);
+        assertTrue(nextSunset < (DAYTOMILIS + SECONDTOMILIS));
     }
 
     /**

--- a/perseo-utils/src/test/java/com/telefonica/iot/perseo/utils/DateTimeUtilsTest.java
+++ b/perseo-utils/src/test/java/com/telefonica/iot/perseo/utils/DateTimeUtilsTest.java
@@ -103,9 +103,9 @@ public class DateTimeUtilsTest extends TestCase {
      */
     public void testTimeToUTC() {
         System.out.println("timeToUTC");
-        int hour = 10;
+        int hour = 3;
         String timeZone = "CET";
         int hourUTC = DateTimeUtils.timeToUTC(hour, timeZone);
-        assertTrue(hourUTC == 9);
+        assertTrue(hourUTC < hour);
     }
 }


### PR DESCRIPTION
This PR edits tests to consider summer time since it was not considered initially.

Also, two new functions were added to library perseo-utils.