### PR TITLE
[WIP] Update pom.xml (update log4j to 1.2.27 due to security vulnerabilities)

### DIFF
--- a/perseo-utils/pom.xml
+++ b/perseo-utils/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>1.2.27</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
issue https://github.com/telefonicaid/perseo-core/network/alerts


CVE-2019-17571
moderate severity
Vulnerable versions: >= 1.2, <= 1.2.27
Patched version: No fix

Included in Log4j 1.2 is a SocketServer class that is vulnerable to deserialization of untrusted data which can be exploited to remotely execute arbitrary code when combined with a deserialization gadget when listening to untrusted network traffic for log data. This affects Log4j versions up to 1.2 up to 1.2.17.
