### PR TITLE
Update to openjdk-11

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Haredning: add json library as proper dependency in pom.xml (version 20180813) instead of third-party source code
 - Hardening: software quality improvement based on ISO25010 recommendations 
+- Fix: upgrade openjdk-8-jdk to openjdk-11-jdk in Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,13 @@ ADD perseo-utils /code/perseo-utils/
 ADD perseo_core-entrypoint.sh /code
 
 RUN apt-get update && \
-    apt-get install -y maven openjdk-8-jdk && \
+    apt-get install -y maven openjdk-9-jdk && \
     mvn install && \
     mvn package && \
     rm -rf /usr/local/tomcat/webapps/* && \
     cp perseo-main/target/perseo-main-*.war /usr/local/tomcat/webapps/perseo-core.war && \
     mvn clean && \
-    apt-get remove -y openjdk-8-jdk && \
+    apt-get remove -y openjdk-9-jdk && \
     apt-get clean && \
     apt-get remove -y maven && \
     apt-get -y autoremove && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,13 @@ ADD perseo-utils /code/perseo-utils/
 ADD perseo_core-entrypoint.sh /code
 
 RUN apt-get update && \
-    apt-get install -y maven openjdk-9-jdk && \
+    apt-get install -y maven openjdk-11-jdk && \
     mvn install && \
     mvn package && \
     rm -rf /usr/local/tomcat/webapps/* && \
     cp perseo-main/target/perseo-main-*.war /usr/local/tomcat/webapps/perseo-core.war && \
     mvn clean && \
-    apt-get remove -y openjdk-9-jdk && \
+    apt-get remove -y openjdk-11-jdk && \
     apt-get clean && \
     apt-get remove -y maven && \
     apt-get -y autoremove && \


### PR DESCRIPTION
openjdk8 missed in tomcat 8 image:
https://hub.docker.com/repository/registry-1.docker.io/telefonicaiot/perseo-core/builds/e0ea3c27-e28c-4b60-99ee-a86a8d745eb2

tomcat 8 image uses debian buster, where openjdk version available is 11