### PR TITLE
[WIP] Task/migrate epl 8.7

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Upgrade to use Esper 8.6 from Exper 7.X (#136)
+- Upgrade to use Esper 8.7 from Exper 7.X (#136)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Upgrade to use Esper 8.7 from Exper 7.X (#136)
+- Upgrade to use Esper 8.4 from Exper 7.X (#136)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Upgrade to use Esper 8.6 from Exper 7.X (#136)

--- a/perseo-main/pom.xml
+++ b/perseo-main/pom.xml
@@ -63,10 +63,25 @@
             <version>8.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- <dependency> -->
+        <!--     <groupId>com.espertech</groupId> -->
+        <!--     <artifactId>esper</artifactId> -->
+        <!--     <version>7.1.0</version> -->
+        <!-- </dependency> -->
         <dependency>
             <groupId>com.espertech</groupId>
-            <artifactId>esper</artifactId>
-            <version>7.1.0</version>
+            <artifactId>esper-runtime</artifactId>
+            <version>8.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.espertech</groupId>
+            <artifactId>esper-common</artifactId>
+            <version>8.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.espertech</groupId>
+            <artifactId>esper-compiler</artifactId>
+            <version>8.4.0</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/perseo-main/pom.xml
+++ b/perseo-main/pom.xml
@@ -71,17 +71,17 @@
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper-runtime</artifactId>
-            <version>8.4.0</version>
+            <version>8.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper-common</artifactId>
-            <version>8.4.0</version>
+            <version>8.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper-compiler</artifactId>
-            <version>8.4.0</version>
+            <version>8.7.0</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/perseo-main/pom.xml
+++ b/perseo-main/pom.xml
@@ -71,17 +71,17 @@
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper-runtime</artifactId>
-            <version>8.7.0</version>
+            <version>8.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper-common</artifactId>
-            <version>8.7.0</version>
+            <version>8.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.espertech</groupId>
             <artifactId>esper-compiler</artifactId>
-            <version>8.7.0</version>
+            <version>8.4.0</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/EventsServlet.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/EventsServlet.java
@@ -45,7 +45,7 @@ public class EventsServlet extends HttpServlet {
 
     private static final Logger logger = LoggerFactory.getLogger(EventsServlet.class);
     //private static EPServiceProvider epService;
-    private static EPRuntime epService;    
+    private static EPRuntime epService;
 
     @Override
     public void init() {
@@ -87,7 +87,8 @@ public class EventsServlet extends HttpServlet {
             logger.debug(String.format("event as JSONObject: %s", jo));
             Map<String, Object> eventMap = Utils.JSONObject2Map(jo);
             logger.debug(String.format("event as map: %s" , eventMap));
-            epService.getEPRuntime().sendEvent(eventMap, Constants.IOT_EVENT);
+            //epService.getEPRuntime().sendEvent(eventMap, Constants.IOT_EVENT);
+            epService.getEventService().sendEventMap(eventMap, Constants.IOT_EVENT);
 
             logger.debug(String.format("event was sent: %s", eventMap));
         } catch (Exception je) {

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/EventsServlet.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/EventsServlet.java
@@ -18,7 +18,8 @@
 */
 package com.telefonica.iot.perseo;
 
-import com.espertech.esper.client.EPServiceProvider;
+//import com.espertech.esper.client.EPServiceProvider;
+import com.espertech.esper.runtime.client.EPRuntime;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Map;
@@ -43,7 +44,8 @@ import org.owasp.encoder.Encode;
 public class EventsServlet extends HttpServlet {
 
     private static final Logger logger = LoggerFactory.getLogger(EventsServlet.class);
-    private static EPServiceProvider epService;
+    //private static EPServiceProvider epService;
+    private static EPRuntime epService;    
 
     @Override
     public void init() {

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/GenericListener.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/GenericListener.java
@@ -26,7 +26,9 @@ import com.espertech.esper.common.client.EventBean;
 //import com.espertech.esper.client.PropertyAccessException;
 import com.espertech.esper.common.client.PropertyAccessException;
 //import com.espertech.esper.client.UpdateListener;
-import com.espertech.esper.common.client.UpdateListener;
+import com.espertech.esper.runtime.client.UpdateListener;
+import com.espertech.esper.runtime.client.EPStatement;
+import com.espertech.esper.runtime.client.EPRuntime;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +45,7 @@ public class GenericListener implements UpdateListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericListener.class);
     
      /**
-     * Implements method to execute an action whe a rule is fired . It makes an
+     * Implements method to execute an action when a rule is fired . It makes an
      * HTTP POST to the configured URL sending the JSON representation of the
      * Events fired by the rule. If the activated rule is a timed rule, this
      * method set the correct headers for the request.
@@ -51,7 +53,7 @@ public class GenericListener implements UpdateListener {
      * @param oldEvents old events leaving the window
      */
     @Override
-    public void update(EventBean[] newEvents, EventBean[] oldEvents) {
+    public void update(EventBean[] newEvents, EventBean[] oldEvents, EPStatement statement ,EPRuntime epruntime) {
         try {          
             for (EventBean event : newEvents) {
 

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/GenericListener.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/GenericListener.java
@@ -61,18 +61,21 @@ public class GenericListener implements UpdateListener {
                 Map<String, Object> eventMap = Utils.JSONObject2Map(jo);
 
                 // Get Rule Information from TimeRulesStore
-                JSONObject rule = TimeRulesStore.getInstance().getRuleInfo((String) eventMap.get("ruleName"));
+                String ruleName = (String) eventMap.get("ruleName");
+                JSONObject rule = TimeRulesStore.getInstance().getRuleInfo(ruleName);
 
                 // Alt. if event.getEventType().getName().endsWith("_wrapoutwild_") -> Timed rule?
                 if (rule != null) {
 
                     // Is a timed Rule. Set special headers using rule saved information
                     Utils.setTimerRuleHeaders(rule);
-                    LOGGER.info(String.format("Firing temporal rule: %s",event));
+                    LOGGER.info(String.format("Firing temporal rule: %s with name %s from event: %s",
+                                               rule.toString(), ruleName, event));
 
                 } else {
 
-                    LOGGER.info(String.format("Firing Rule: %s",event));
+                    LOGGER.info(String.format("Firing Rule with name: %s from Event: %s",
+                                              ruleName, event));
                 }
 
                 LOGGER.debug(String.format("result errors: %s",jo.optJSONObject("errors")));

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/GenericListener.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/GenericListener.java
@@ -53,7 +53,7 @@ public class GenericListener implements UpdateListener {
      * @param oldEvents old events leaving the window
      */
     @Override
-    public void update(EventBean[] newEvents, EventBean[] oldEvents, EPStatement statement ,EPRuntime epruntime) {
+    public void update(EventBean[] newEvents, EventBean[] oldEvents, EPStatement statement, EPRuntime epruntime) {
         try {          
             for (EventBean event : newEvents) {
 

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/GenericListener.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/GenericListener.java
@@ -21,9 +21,12 @@
 
 package com.telefonica.iot.perseo;
 
-import com.espertech.esper.client.EventBean;
-import com.espertech.esper.client.PropertyAccessException;
-import com.espertech.esper.client.UpdateListener;
+//import com.espertech.esper.client.EventBean;
+import com.espertech.esper.common.client.EventBean;
+//import com.espertech.esper.client.PropertyAccessException;
+import com.espertech.esper.common.client.PropertyAccessException;
+//import com.espertech.esper.client.UpdateListener;
+import com.espertech.esper.common.client.UpdateListener;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
@@ -155,12 +155,13 @@ public class RulesManager {
 
                 EPDeployment deployment = Utils.compileDeploy(epService, newEpl, name);
                 String dId = deployment.getDeploymentId();
+                statement = deployment.getStatements()[0];
                 logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
-                                                                                            deployment.getStatements()[0],
+                                                                                            statement,
                                                                                             epa,
                                                                                             dId
                                                                                             )));
-                deployment.getStatements()[0].addListener(new GenericListener());
+                statement.addListener(new GenericListener());
             } else {
                 //String oldEpl = prevStmnt.getText();
                 String oldEpl = prevStmnt.getProperty(StatementProperty.EPL).toString();
@@ -178,12 +179,13 @@ public class RulesManager {
 
                     EPDeployment deployment = Utils.compileDeploy(epService, newEpl, name);
                     String dId = deployment.getDeploymentId();
+                    statement = deployment.getStatements()[0];
                     logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
-                                                                                                deployment.getStatements()[0],
+                                                                                                statement,
                                                                                                 epa,
                                                                                                 dId
                                                                                                 )));
-                    deployment.getStatements()[0].addListener(new GenericListener());
+                    statement.addListener(new GenericListener());
                 } else {
                     logger.debug(String.format("found repeated statement: %s", name));
                     statement = prevStmnt;

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashMap;
 import javax.servlet.http.HttpServletResponse;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -73,24 +74,15 @@ public class RulesManager {
             EPDeploymentService epa = epService.getDeploymentService();
 
             if (ruleName.length() != 0) {
-                EPStatement st = null;
-                String[] deploymentIds = epa.getDeployments();
-                String dId = null;
-                for (String deploymentId : deploymentIds) {
-                    st = epa.getStatement(deploymentId, ruleName);
-                    if (st != null) {
-                        dId = deploymentId;
-                        break;
-                    }
-                }
                 // EPStatement st = epa.getStatement(ruleName);
+                EPStatement st = Utils.getStatementFromDeployService(epa, ruleName);
                 if (st == null) {
                     return new Result(HttpServletResponse.SC_NOT_FOUND,
                             String.format("{\"error\":\"%s not found\"}%n",
                                     ruleName));
                 } else {
                     return new Result(HttpServletResponse.SC_OK,
-                                      Utils.Statement2JSONObject(st,epa, dId).toString());
+                                      Utils.Statement2JSONObject(st, epa, st.getDeploymentId()).toString());
                 }
             } else {
                 JSONArray ja = new JSONArray();
@@ -153,44 +145,22 @@ public class RulesManager {
          
             EPStatement statement = null;
             //EPStatement prevStmnt = epService.getEPAdministrator().getStatement(name);
-            EPStatement prevStmnt = null;
             EPDeploymentService epa = epService.getDeploymentService();
-            String[] deploymentIds = epa.getDeployments();
-            String dId = null;
-            for (String deploymentId : deploymentIds) {
-                EPStatement st = epa.getStatement(deploymentId, name);
-                if (st != null) {
-                    prevStmnt = st;
-                    dId = deploymentId;
-                    break;
-                }
-            }
-
-            // Deployment for compile newEPL
-            com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
-            CompilerArguments arguments = new CompilerArguments(configuration);
-            arguments.getPath().add(epService.getRuntimePath());
-            EPCompiled epCompiled = null;
-            try {
-                epCompiled = EPCompilerProvider.getCompiler().compile(newEpl, arguments);
-            } catch (EPCompileException ex) {
-                throw new RuntimeException(ex);
-            }
-            EPDeployment deploymentForEPL;
-            try {
-                deploymentForEPL = epa.deploy(epCompiled);
-            } catch (EPDeployException ex) {
-                throw new RuntimeException(ex);
-            }
+            EPStatement prevStmnt = Utils.getStatementFromDeployService(epa, name);
 
             if (prevStmnt == null) {
-                logger.debug(String.format("found new statement: %s",name));
+                logger.debug(String.format("found new statement: %s", name));
 
                 //statement = epService.getEPAdministrator().createEPL(newEpl, name);
-                dId = deploymentForEPL.getDeploymentId();
-                statement = epService.getDeploymentService().getStatement(dId, name);
-                logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(statement, epa, dId)));
-                statement.addListener(new GenericListener());
+
+                EPDeployment deployment = Utils.compileDeploy(epService, newEpl, name);
+                String dId = deployment.getDeploymentId();
+                logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
+                                                                                            deployment.getStatements()[0],
+                                                                                            epa,
+                                                                                            dId
+                                                                                            )));
+                deployment.getStatements()[0].addListener(new GenericListener());
             } else {
                 //String oldEpl = prevStmnt.getText();
                 String oldEpl = prevStmnt.getProperty(StatementProperty.EPL).toString();
@@ -199,25 +169,28 @@ public class RulesManager {
                     logger.debug(String.format("found changed statement: %s",name));
                     //prevStmnt.destroy();
                     try {
-                        epa.undeploy(dId);
+                        epa.undeploy(prevStmnt.getDeploymentId());
                     } catch (EPUndeployException ex) {
                         throw new RuntimeException(ex);
                     }
                     logger.debug(String.format("deleted statement: %s",name));
                     //statement = epService.getEPAdministrator().createEPL(newEpl, name);
-                    dId = deploymentForEPL.getDeploymentId();
-                    statement = epService.getDeploymentService().getStatement(dId, name);
-                    
-                    logger.debug(String.format("re-created statement: %s", name));
-                    logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(statement, epa, dId)));
-                    statement.addListener(new GenericListener());
+
+                    EPDeployment deployment = Utils.compileDeploy(epService, newEpl, name);
+                    String dId = deployment.getDeploymentId();
+                    logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
+                                                                                                deployment.getStatements()[0],
+                                                                                                epa,
+                                                                                                dId
+                                                                                                )));
+                    deployment.getStatements()[0].addListener(new GenericListener());
                 } else {
                     logger.debug(String.format("found repeated statement: %s", name));
                     statement = prevStmnt;
                 }
             }
             return new Result(HttpServletResponse.SC_OK,
-                              Utils.Statement2JSONObject(statement, epa, dId).toString());
+                              Utils.Statement2JSONObject(statement, epa, statement.getDeploymentId()).toString());
         } catch (EPException epe) {
             logger.error(String.format("creating statement %s", epe));
             return new Result(HttpServletResponse.SC_BAD_REQUEST,
@@ -283,43 +256,20 @@ public class RulesManager {
             for (String n : newOnes.keySet()) {
                 String newEpl = newOnes.get(n);
 
-                // Deployment for compile newEPL
-                Configuration configuration = new Configuration();
-                CompilerArguments arguments = new CompilerArguments(configuration);
-                arguments.getPath().add(epService.getRuntimePath());
-                EPCompiled epCompiled = null;
-                try {
-                    epCompiled = EPCompilerProvider.getCompiler().compile(newEpl, arguments);
-                } catch (EPCompileException ex) {
-                    throw new RuntimeException(ex);
-                }
-                EPDeployment deploymentForEPL;
-                try {
-                    deploymentForEPL = epService.getDeploymentService().deploy(epCompiled);
-                } catch (EPDeployException ex) {
-                    throw new RuntimeException(ex);
-                }
-
                 if (!oldOnesNames.contains(n)) {
                     logger.debug(String.format("found new statement: %s", n));
                     //EPStatement statement = epService.getEPAdministrator().createEPL(newEpl, n);
-                    String dId = deploymentForEPL.getDeploymentId();
-                    EPStatement statement = epService.getDeploymentService().getStatement(dId, n);
-                    logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(statement, epa, dId)));
-                    statement.addListener(new GenericListener());
+
+                    EPDeployment deployment = Utils.compileDeploy(epService, newEpl, n);
+                    logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
+                                                                                                deployment.getStatements()[0],
+                                                                                                epa,
+                                                                                                deployment.getDeploymentId()
+                                                                                                )));
+                    deployment.getStatements()[0].addListener(new GenericListener());
                 } else {
                     //EPStatement prevStmnt = epService.getEPAdministrator().getStatement(n);
-                    EPStatement prevStmnt = null;
-                    deploymentIds = epa.getDeployments();
-                    String dId = null;
-                    for (String deploymentId : deploymentIds) {
-                        EPStatement st = epa.getStatement(deploymentId, n);
-                        if (st != null) {
-                            prevStmnt = st;
-                            dId = deploymentId;
-                            break;
-                        }
-                    }
+                    EPStatement prevStmnt = Utils.getStatementFromDeployService(epa, n);
 
                     //String oldEPL = prevStmnt.getText();
                     String oldEPL = prevStmnt.getProperty(StatementProperty.EPL).toString();
@@ -327,17 +277,20 @@ public class RulesManager {
                         logger.debug(String.format("found changed statement: %s", n));
                         //prevStmnt.destroy();
                         try {
-                            epa.undeploy(dId);
+                            epa.undeploy(prevStmnt.getDeploymentId());
                         } catch (EPUndeployException ex) {
                             throw new RuntimeException(ex);
                         }
                         logger.debug(String.format("deleted statement: %s", n));
                         //EPStatement statement = epService.getEPAdministrator().createEPL(newEpl, n);
-                        dId = deploymentForEPL.getDeploymentId();
-                        EPStatement statement = epService.getDeploymentService().getStatement(dId, n);
-                        logger.debug(String.format("re-created statement: %s" ,n));
-                        logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(statement, epa, dId)));
-                        statement.addListener(new GenericListener());
+
+                        EPDeployment deployment = Utils.compileDeploy(epService, newEpl, n);
+                        logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
+                                                                                                    deployment.getStatements()[0],
+                                                                                                    epa,
+                                                                                                    deployment.getDeploymentId()
+                                                                                                    )));
+                        deployment.getStatements()[0].addListener(new GenericListener());
                     } else {
                         logger.debug(String.format("identical statement: %s", n));
                     }
@@ -347,20 +300,11 @@ public class RulesManager {
             //Delete oldOnes if they are old enough
             for (String o : oldOnesNames) {
                 //EPStatement prevStmnt = epService.getEPAdministrator().getStatement(o);
-                EPStatement prevStmnt = null;
-                deploymentIds = epa.getDeployments();
-                String dId = null;
-                for (String deploymentId : deploymentIds) {
-                    EPStatement st = epa.getStatement(deploymentId, o);
-                    if (st != null) {
-                        prevStmnt = st;
-                        dId = deploymentId;
-                        break;
-                    }
-                }
+                EPStatement prevStmnt = Utils.getStatementFromDeployService(epa, o);
 
                 logger.debug(String.format("unexpected statement: %s", o));
                 //if (prevStmnt.getTimeLastStateChange() < now - maxAge) {
+                String dId = prevStmnt.getDeploymentId();
                 if (epa.getDeployment(dId).getLastUpdateDate().getTime() < now - maxAge) {
                     logger.debug(String.format("unexpected statement, too old: %s", o));
                     //prevStmnt.destroy();
@@ -405,18 +349,8 @@ public class RulesManager {
 
             if (ruleName.length() != 0) {
                 //EPStatement st = epa.getStatement(ruleName);
-                EPStatement st = null;
-                String[] deploymentIds = epa.getDeployments();
-                String dId = null;
-                for (String deploymentId : deploymentIds) {
-                    EPStatement currentst = epa.getStatement(deploymentId, ruleName);
-                    if (currentst != null) {
-                        st = currentst;
-                        dId = deploymentId;
-                        break;
-                    }
-                }
-
+                EPStatement st = Utils.getStatementFromDeployService(epa, ruleName);
+                String dId = st.getDeploymentId();
                 //Allow to delete inexistent rule
                 if (st != null) {
                     //st.destroy();
@@ -429,7 +363,7 @@ public class RulesManager {
                     return new Result(HttpServletResponse.SC_OK,
                                       Utils.Statement2JSONObject(st, epa, dId).toString());
                 } else {
-                    logger.debug(String.format("asked for deleting inexistent statement: %s",ruleName));
+                    logger.debug(String.format("asked for deleting inexistent statement: %s", ruleName));
                     return new Result(HttpServletResponse.SC_OK, "{}");
                 }
 

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.ArrayList;
 import javax.servlet.http.HttpServletResponse;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -171,8 +170,9 @@ public class RulesManager {
             com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
             CompilerArguments arguments = new CompilerArguments(configuration);
             arguments.getPath().add(epService.getRuntimePath());
+            EPCompiled epCompiled = null;
             try {
-                EPCompiled epCompiled = EPCompilerProvider.getCompiler().compile(newEpl, arguments);
+                epCompiled = EPCompilerProvider.getCompiler().compile(newEpl, arguments);
             } catch (EPCompileException ex) {
                 throw new RuntimeException(ex);
             }
@@ -287,8 +287,9 @@ public class RulesManager {
                 Configuration configuration = new Configuration();
                 CompilerArguments arguments = new CompilerArguments(configuration);
                 arguments.getPath().add(epService.getRuntimePath());
+                EPCompiled epCompiled = null;
                 try {
-                    EPCompiled epCompiled = EPCompilerProvider.getCompiler().compile(newEpl, arguments);
+                    epCompiled = EPCompilerProvider.getCompiler().compile(newEpl, arguments);
                 } catch (EPCompileException ex) {
                     throw new RuntimeException(ex);
                 }

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
@@ -180,6 +180,7 @@ public class RulesManager {
                     EPDeployment deployment = Utils.compileDeploy(epService, newEpl, name);
                     String dId = deployment.getDeploymentId();
                     statement = deployment.getStatements()[0];
+                    logger.debug(String.format("re-created statement: %s", name));
                     logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
                                                                                                 statement,
                                                                                                 epa,
@@ -263,7 +264,7 @@ public class RulesManager {
                     //EPStatement statement = epService.getEPAdministrator().createEPL(newEpl, n);
 
                     EPDeployment deployment = Utils.compileDeploy(epService, newEpl, n);
-                    logger.info(String.format("statement json: %s", Utils.Statement2JSONObject(
+                    logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
                                                                                                 deployment.getStatements()[0],
                                                                                                 epa,
                                                                                                 deployment.getDeploymentId()
@@ -287,6 +288,7 @@ public class RulesManager {
                         //EPStatement statement = epService.getEPAdministrator().createEPL(newEpl, n);
 
                         EPDeployment deployment = Utils.compileDeploy(epService, newEpl, n);
+                        logger.debug(String.format("re-created statement: %s" ,n));
                         logger.debug(String.format("statement json: %s", Utils.Statement2JSONObject(
                                                                                                     deployment.getStatements()[0],
                                                                                                     epa,
@@ -304,11 +306,11 @@ public class RulesManager {
                 //EPStatement prevStmnt = epService.getEPAdministrator().getStatement(o);
                 EPStatement prevStmnt = Utils.getStatementFromDeployService(epa, o);
 
-                logger.info(String.format("unexpected statement: %s", o));
+                logger.debug(String.format("unexpected statement: %s", o));
                 //if (prevStmnt.getTimeLastStateChange() < now - maxAge) {
                 String dId = prevStmnt.getDeploymentId();
                 if (epa.getDeployment(dId).getLastUpdateDate().getTime() < now - maxAge) {
-                    logger.info(String.format("unexpected statement, too old: %s", o));
+                    logger.debug(String.format("unexpected statement, too old: %s", o));
                     //prevStmnt.destroy();
                     try {
                         epa.undeploy(dId);

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesManager.java
@@ -356,14 +356,14 @@ public class RulesManager {
                 //Allow to delete inexistent rule
                 if (st != null) {
                     //st.destroy();
+                    String stString = Utils.Statement2JSONObject(st, epa, dId).toString();
                     try {
                         epa.undeploy(dId);
                     } catch (EPUndeployException ex) {
                         throw new RuntimeException(ex);
                     }
                     logger.debug(String.format("deleted statement: %s", ruleName));
-                    return new Result(HttpServletResponse.SC_OK,
-                                      Utils.Statement2JSONObject(st, epa, dId).toString());
+                    return new Result(HttpServletResponse.SC_OK, stString);
                 } else {
                     logger.debug(String.format("asked for deleting inexistent statement: %s", ruleName));
                     return new Result(HttpServletResponse.SC_OK, "{}");

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesServlet.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesServlet.java
@@ -21,7 +21,8 @@
 
 package com.telefonica.iot.perseo;
 
-import com.espertech.esper.client.EPServiceProvider;
+//import com.espertech.esper.client.EPServiceProvider;
+import com.espertech.esper.runtime.client.EPRuntime;
 import java.io.IOException;
 import java.io.PrintWriter;
 import javax.servlet.ServletContext;
@@ -43,7 +44,8 @@ import org.slf4j.LoggerFactory;
 public class RulesServlet extends HttpServlet {
 
     private static final Logger logger = LoggerFactory.getLogger(RulesServlet.class);
-    private static EPServiceProvider epService;
+    //private static EPServiceProvider epService;
+    private static EPRuntime epService;    
 
     @Override
     public void init() throws ServletException {

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesServlet.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/RulesServlet.java
@@ -45,7 +45,7 @@ public class RulesServlet extends HttpServlet {
 
     private static final Logger logger = LoggerFactory.getLogger(RulesServlet.class);
     //private static EPServiceProvider epService;
-    private static EPRuntime epService;    
+    private static EPRuntime epService;
 
     @Override
     public void init() throws ServletException {

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -129,7 +129,6 @@ public class Utils {
             }
 
             epService = EPRuntimeProvider.getDefaultRuntime(configuration);
-            //epService.initialize();
 
             sc.setAttribute(EPSERV_ATTR_NAME, epService);
         }

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -212,6 +212,18 @@ public class Utils {
         return jo;
     }
 
+    public static JSONObject Statement2JSONObject(EPStatement st, EPDeploymentService epService, String deploymentId) {
+        if (st == null) {
+            return null;
+        }
+        JSONObject jo = new JSONObject()
+                .put("name", st.getName())
+                .put("text", st.getProperty(StatementProperty.EPL))
+                .put("state", st.isDestroyed())
+                .put("timeLastStateChange", epService.getDeployment(deploymentId).getLastUpdateDate());
+        return jo;
+    }
+
     /**
      * Makes an HTTP POST to an URL sending an body. The URL and body are
      * represented as String.

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -28,6 +28,7 @@ import com.espertech.esper.compiler.client.CompilerArguments;
 import com.espertech.esper.compiler.client.option.StatementNameOption;
 import com.espertech.esper.compiler.client.option.StatementNameContext;
 import com.espertech.esper.compiler.client.EPCompilerProvider;
+import com.espertech.esper.common.client.util.EventTypeBusModifier;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -77,6 +78,9 @@ public class Utils {
         com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
         //configuration.getEngineDefaults().getExpression().setUdfCache(false);
         configuration.getCompiler().getExpression().setUdfCache(false);
+        configuration.getCompiler().getByteCode().setAllowSubscriber(true);
+        configuration.getCompiler().getByteCode().setAccessModifiersPublic();
+        configuration.getCompiler().getByteCode().setBusModifierEventType(EventTypeBusModifier.BUS);
         //EPServiceProvider epService = (EPServiceProvider) sc.getAttribute(EPSERV_ATTR_NAME);
         EPRuntime epService = (EPRuntime) sc.getAttribute(EPSERV_ATTR_NAME);
         if (epService == null) {
@@ -88,7 +92,7 @@ public class Utils {
             def.put(Constants.SUBSERVICE_FIELD, String.class);
             def.put(Constants.SERVICE_FIELD, String.class);
 
-            configuration.getCommon().addEventType("iotEvent", def);
+            configuration.getCommon().addEventType(Constants.IOT_EVENT, def);
 
             //ConfigurationOperations cfg = epService.getEPAdministrator().getConfiguration();
             //cfg.addEventType(Constants.IOT_EVENT, def);
@@ -410,7 +414,9 @@ public class Utils {
         try {
             // Obtain a copy of the engine configuration
             com.espertech.esper.common.client.configuration.Configuration configuration = runtime.getConfigurationDeepCopy();
-
+            configuration.getCompiler().getByteCode().setAllowSubscriber(true);
+            configuration.getCompiler().getByteCode().setAccessModifiersPublic();
+            configuration.getCompiler().getByteCode().setBusModifierEventType(EventTypeBusModifier.BUS);
             Map<String, Object> def = new HashMap<String, Object>();
             def.put("id", String.class);
             def.put("type", String.class);

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -439,7 +439,7 @@ public class Utils {
             return runtime.getDeploymentService().deploy(compiled);
         }
         catch (Exception ex) {
-            throw new RuntimeException(ex);
+            throw new EPException(ex.getMessage());
         }
     }
 
@@ -459,7 +459,7 @@ public class Utils {
             return st;
         }
         catch (Exception ex) {
-            throw new RuntimeException(ex);
+            throw new EPException(ex.getMessage());
         }
     }
 

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -20,8 +20,10 @@
 */
 package com.telefonica.iot.perseo;
 
-import com.espertech.esper.client.*;
-
+//import com.espertech.esper.client.*;
+import com.espertech.esper.runtime.client.*;
+import com.espertech.esper.common.client.*;
+    
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,7 +39,7 @@ import java.util.Map;
 import java.util.UUID;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
-import com.espertech.esper.client.Configuration;
+//import com.espertech.esper.client.Configuration;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -62,18 +64,23 @@ public class Utils {
      * @param sc ServleContext to add ESPServiceProvider
      * @return the initialized EPServiceProvider
      */
-    public static synchronized EPServiceProvider initEPService(ServletContext sc) {
+    //public static synchronized EPServiceProvider initEPService(ServletContext sc) {
+    public static synchronized EPRuntime initEPService(ServletContext sc) {        
         Configuration configuration = new Configuration();
         configuration.getEngineDefaults().getExpression().setUdfCache(false);
-        EPServiceProvider epService = (EPServiceProvider) sc.getAttribute(EPSERV_ATTR_NAME);
+        //EPServiceProvider epService = (EPServiceProvider) sc.getAttribute(EPSERV_ATTR_NAME);
+        EPRuntime epService = (EPRuntime) sc.getAttribute(EPSERV_ATTR_NAME);
         if (epService == null) {
-            epService = EPServiceProviderManager.getDefaultProvider(configuration);
+            //epService = EPServiceProviderManager.getDefaultProvider(configuration);
+            epService = EPRuntimeProvider.getDefaultRuntime(configuration);            
             Map<String, Object> def = new HashMap<String, Object>();
             def.put("id", String.class);
             def.put("type", String.class);
             def.put(Constants.SUBSERVICE_FIELD, String.class);
             def.put(Constants.SERVICE_FIELD, String.class);
-            ConfigurationOperations cfg = epService.getEPAdministrator().getConfiguration();
+            //ConfigurationOperations cfg = epService.getEPAdministrator().getConfiguration();
+            Configuration cfgCopy = epService.getConfigurationDeepCopy();
+            ConfigurationCommon cfg = cfgCopy.getCommon();
             cfg.addEventType(Constants.IOT_EVENT, def);
 
             // Add perseo-utils library
@@ -119,7 +126,8 @@ public class Utils {
      * @param sc ServleContext to add ESPServiceProvider
      */
     public static synchronized void destroyEPService(ServletContext sc) {
-        EPServiceProvider epService = (EPServiceProvider) sc.getAttribute(EPSERV_ATTR_NAME);
+        //EPServiceProvider epService = (EPServiceProvider) sc.getAttribute(EPSERV_ATTR_NAME);
+        EPRuntime epService = (EPRuntime) sc.getAttribute(EPSERV_ATTR_NAME);        
         if (epService != null) {
             epService.destroy();
             sc.removeAttribute(EPSERV_ATTR_NAME);

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/GenericListenerTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/GenericListenerTest.java
@@ -21,8 +21,11 @@
 
 package com.telefonica.iot.perseo;
 
-import com.espertech.esper.client.EventBean;
+//import com.espertech.esper.client.EventBean;
+import com.espertech.esper.common.client.EventBean;
 import com.telefonica.iot.perseo.test.EventBeanMock;
+import com.espertech.esper.runtime.client.EPStatement;
+import com.espertech.esper.runtime.client.EPRuntime;
 import java.util.HashMap;
 
 import org.json.JSONObject;
@@ -69,13 +72,14 @@ public class GenericListenerTest {
         EventBean[] newEvents = new EventBean[0];
         EventBean[] oldEvents = new EventBean[0];
         GenericListener instance = new GenericListener();
-        instance.update(newEvents, oldEvents);
+        //instance.update(newEvents, oldEvents);
+        instance.update(newEvents, oldEvents, null, null);
         HashMap<String, Object> m = new HashMap();
         m.put("one", "1");
         m.put("two", 2);
         EventBean event = new EventBeanMock(m);
         newEvents = new EventBean[]{event};
-        instance.update(newEvents, oldEvents);
+        instance.update(newEvents, oldEvents, null, null);
     }
 
     /**
@@ -104,7 +108,7 @@ public class GenericListenerTest {
         m.put("ruleName", "testrule");
         EventBean event = new EventBeanMock(m);
         EventBean[] newEvents = new EventBean[]{event};
-        instance.update(newEvents, oldEvents);
+        instance.update(newEvents, oldEvents, null, null);
         tRInfoInstance.cleanAllRules();
     }
 

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesManagerTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesManagerTest.java
@@ -19,10 +19,27 @@
 
 package com.telefonica.iot.perseo;
 
-import com.espertech.esper.client.ConfigurationOperations;
-import com.espertech.esper.client.EPServiceProvider;
-import com.espertech.esper.client.EPServiceProviderManager;
-import com.espertech.esper.client.EPStatement;
+//import com.espertech.esper.client.ConfigurationOperations;
+import com.espertech.esper.common.client.configuration.Configuration;
+import com.espertech.esper.common.client.configuration.*;
+import com.espertech.esper.common.client.configuration.common.*;
+import com.espertech.esper.common.client.configuration.compiler.*;
+//import com.espertech.esper.client.EPServiceProvider;
+import com.espertech.esper.runtime.client.EPRuntime;
+//import com.espertech.esper.client.EPServiceProviderManager;
+import com.espertech.esper.runtime.client.EPRuntimeProvider;
+//import com.espertech.esper.client.EPStatement;
+import com.espertech.esper.runtime.client.EPStatement;
+import com.espertech.esper.runtime.client.EPDeploymentService;
+import com.espertech.esper.runtime.client.EPDeployment;
+import com.espertech.esper.common.client.EPException;
+import com.espertech.esper.compiler.client.CompilerArguments;
+import com.espertech.esper.common.client.EPCompiled;
+import com.espertech.esper.compiler.client.EPCompilerProvider;
+import com.espertech.esper.compiler.client.EPCompileException;
+import com.espertech.esper.runtime.client.EPDeployException;
+import com.espertech.esper.runtime.client.EPUndeployException;
+import com.espertech.esper.common.client.util.StatementProperty;
 import com.telefonica.iot.perseo.test.Help;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +50,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.ArrayList;
 
 import static org.junit.Assert.*;
 
@@ -42,17 +60,21 @@ import static org.junit.Assert.*;
  */
 public class RulesManagerTest {
 
-    EPServiceProvider epService;
+    //EPServiceProvider epService;
+    EPRuntime epService;
     private static final Logger logger = LoggerFactory.getLogger(RulesManagerTest.class);
     public RulesManagerTest() {
-        epService = EPServiceProviderManager.getDefaultProvider();
+        //epService = EPServiceProviderManager.getDefaultProvider();
+        epService = EPRuntimeProvider.getDefaultRuntime();
 
         Map<String, Object> def = new HashMap<String, Object>();
         def.put("id", String.class);
         def.put("type", String.class);
         def.put(Constants.SUBSERVICE_FIELD, String.class);
         def.put(Constants.SERVICE_FIELD, String.class);
-        ConfigurationOperations cfg = epService.getEPAdministrator().getConfiguration();
+        //ConfigurationOperations cfg = epService.getEPAdministrator().getConfiguration();
+        ConfigurationCommon cfg = epService.getConfigurationDeepCopy().getCommon();
+
         cfg.addEventType("iotEvent", def);
     }
 
@@ -66,7 +88,8 @@ public class RulesManagerTest {
 
     @Before
     public void setUp() {
-        epService.getEPAdministrator().destroyAllStatements();
+        //epService.getEPAdministrator().destroyAllStatements();
+        epService.getDeploymentService().undeployAll();
     }
 
     @After
@@ -78,15 +101,50 @@ public class RulesManagerTest {
      */
     @Test
     public void testGet() {
+        EPDeploymentService epa = epService.getDeploymentService();
+
         logger.info("get");
         String ruleName = "ccc";
         String epl = Help.ExampleRules()[0];
-        EPStatement st = epService.getEPAdministrator().createEPL(epl, ruleName);
+        //EPStatement st = epService.getEPAdministrator().createEPL(epl, ruleName);
+
+        // Deployment for compile newEPL
+        com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
+        CompilerArguments arguments = new CompilerArguments(configuration);
+        arguments.getPath().add(epService.getRuntimePath());
+        EPCompiled epCompiled = null;
+        try {
+            epCompiled = EPCompilerProvider.getCompiler().compile(epl, arguments);
+        } catch (EPCompileException ex) {
+            throw new RuntimeException(ex);
+        }
+        EPDeployment deploymentForEPL;
+        try {
+            deploymentForEPL = epa.deploy(epCompiled);
+        } catch (EPDeployException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        String dId = deploymentForEPL.getDeploymentId();
+        EPStatement st = epa.getStatement(dId, ruleName);
         Result result = RulesManager.get(epService, ruleName);
         assertEquals(200, result.getStatusCode());
         result = RulesManager.get(epService, "it does not exist, we hope");
         assertEquals(404, result.getStatusCode());
-        EPStatement st2 = epService.getEPAdministrator().getStatement(ruleName);
+
+
+        //EPStatement st2 = epService.getEPAdministrator().getStatement(ruleName);
+        EPStatement st2 = null;
+        String[] deploymentIds = epa.getDeployments();
+        dId = null;
+        for (String deploymentId : deploymentIds) {
+            st2 = epa.getStatement(deploymentId, ruleName);
+            if (st2 != null) {
+                dId = deploymentId;
+                break;
+            }
+        }
+
         assertEquals(st, st2);
     }
 
@@ -102,8 +160,22 @@ public class RulesManagerTest {
 
         Result result = RulesManager.make(epService, text);
         assertEquals(200, result.getStatusCode());
-        EPStatement st = epService.getEPAdministrator().getStatement(ruleName);
-        assertEquals(epl, st.getText());
+        //EPStatement st = epService.getEPAdministrator().getStatement(ruleName);
+
+        EPDeploymentService epa = epService.getDeploymentService();
+
+        EPStatement st = null;
+        String[] deploymentIds = epa.getDeployments();
+        String dId = null;
+        for (String deploymentId : deploymentIds) {
+            st = epa.getStatement(deploymentId, ruleName);
+            if (st != null) {
+                dId = deploymentId;
+                break;
+            }
+        }
+
+        assertEquals(epl, st.getProperty(StatementProperty.EPL).toString());
         assertEquals(ruleName, st.getName());
     }
 
@@ -119,10 +191,36 @@ public class RulesManagerTest {
 
         Result result = RulesManager.updateAll(epService, text);
         assertEquals(200, result.getStatusCode());
-        String[] names = epService.getEPAdministrator().getStatementNames();
-        assertEquals(1, names.length);
-        EPStatement st = epService.getEPAdministrator().getStatement(ruleName);
-        assertEquals(epl, st.getText());
+
+        EPDeploymentService epa = epService.getDeploymentService();
+
+        //String[] names = epService.getEPAdministrator().getStatementNames();
+
+        ArrayList<String> names = new ArrayList<String>();
+        String[] deploymentIds = epa.getDeployments();
+        for (String deploymentId : deploymentIds) {
+            EPDeployment deployment = epa.getDeployment(deploymentId);
+            EPStatement[] statements = deployment.getStatements();
+            for (EPStatement st : statements) {
+                names.add(st.getName());
+            }
+        }
+
+        assertEquals(1, names.size());
+
+        //EPStatement st = epService.getEPAdministrator().getStatement(ruleName);
+        EPStatement st = null;
+        String[] deploymentIds = epa.getDeployments();
+        String dId = null;
+        for (String deploymentId : deploymentIds) {
+            st = epa.getStatement(deploymentId, ruleName);
+            if (st != null) {
+                dId = deploymentId;
+                break;
+            }
+        }
+
+        assertEquals(epl, st.getProperty(StatementProperty.EPL).toString());
         assertEquals(ruleName, st.getName());
     }
 
@@ -134,11 +232,46 @@ public class RulesManagerTest {
         logger.info("delete");
         String ruleName = "ccc";
         String epl = Help.ExampleRules()[0];
-        EPStatement st = epService.getEPAdministrator().createEPL(epl, ruleName);
+
+        EPDeploymentService epa = epService.getDeploymentService();
+
+        //EPStatement st = epService.getEPAdministrator().createEPL(epl, ruleName);
+
+        // Deployment for compile newEPL
+        com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
+        CompilerArguments arguments = new CompilerArguments(configuration);
+        arguments.getPath().add(epService.getRuntimePath());
+        EPCompiled epCompiled = null;
+        try {
+            epCompiled = EPCompilerProvider.getCompiler().compile(epl, arguments);
+        } catch (EPCompileException ex) {
+            throw new RuntimeException(ex);
+        }
+        EPDeployment deploymentForEPL;
+        try {
+            deploymentForEPL = epa.deploy(epCompiled);
+        } catch (EPDeployException ex) {
+            throw new RuntimeException(ex);
+        }
+        String dId = deploymentForEPL.getDeploymentId();
+        EPStatement st = epa.getStatement(dId, ruleName);
+
         assertNotNull(st);
         Result result = RulesManager.delete(epService, ruleName);
         assertEquals(200, result.getStatusCode());
-        EPStatement st2 = epService.getEPAdministrator().getStatement(ruleName);
+
+        //EPStatement st2 = epService.getEPAdministrator().getStatement(ruleName);
+
+        EPStatement st2 = null;
+        String[] deploymentIds = epa.getDeployments();
+        dId = null;
+        for (String deploymentId : deploymentIds) {
+            st2 = epa.getStatement(deploymentId, ruleName);
+            if (st2 != null) {
+                dId = deploymentId;
+                break;
+            }
+        }
         assertEquals(null, st2);
     }
 }

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesManagerTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesManagerTest.java
@@ -65,7 +65,9 @@ public class RulesManagerTest {
     private static final Logger logger = LoggerFactory.getLogger(RulesManagerTest.class);
     public RulesManagerTest() {
         //epService = EPServiceProviderManager.getDefaultProvider();
-        epService = EPRuntimeProvider.getDefaultRuntime();
+        com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
+        epService = EPRuntimeProvider.getDefaultRuntime(configuration);
+        epService.initialize();
 
         Map<String, Object> def = new HashMap<String, Object>();
         def.put("id", String.class);
@@ -89,7 +91,11 @@ public class RulesManagerTest {
     @Before
     public void setUp() {
         //epService.getEPAdministrator().destroyAllStatements();
-        epService.getDeploymentService().undeployAll();
+        try {
+            epService.getDeploymentService().undeployAll();
+        } catch (EPUndeployException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     @After
@@ -210,7 +216,7 @@ public class RulesManagerTest {
 
         //EPStatement st = epService.getEPAdministrator().getStatement(ruleName);
         EPStatement st = null;
-        String[] deploymentIds = epa.getDeployments();
+        deploymentIds = epa.getDeployments();
         String dId = null;
         for (String deploymentId : deploymentIds) {
             st = epa.getStatement(deploymentId, ruleName);

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesManagerTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesManagerTest.java
@@ -77,7 +77,6 @@ public class RulesManagerTest {
         configuration.getCommon().addEventType("iotEvent", def);
 
         epService = EPRuntimeProvider.getDefaultRuntime(configuration);
-        //epService.initialize(); // ?
     }
 
     @BeforeClass

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesServletTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesServletTest.java
@@ -168,11 +168,7 @@ public class RulesServletTest {
         try {
             String url = String.format("http://127.0.0.1:%d/nothing", Help.PORT);
             Help.Res r = Help.doDelete(url);
-            //assertEquals(200, r.getCode());
-            assertEquals(400, r.getCode());
-            url = String.format("http://127.0.0.1:%d/", Help.PORT);
-            r = Help.doDelete(url);
-            assertEquals(404, r.getCode());
+            assertEquals(200, r.getCode());
         } finally {
             server.stop();
         }

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesServletTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/RulesServletTest.java
@@ -168,7 +168,11 @@ public class RulesServletTest {
         try {
             String url = String.format("http://127.0.0.1:%d/nothing", Help.PORT);
             Help.Res r = Help.doDelete(url);
-            assertEquals(200, r.getCode());
+            //assertEquals(200, r.getCode());
+            assertEquals(400, r.getCode());
+            url = String.format("http://127.0.0.1:%d/", Help.PORT);
+            r = Help.doDelete(url);
+            assertEquals(404, r.getCode());
         } finally {
             server.stop();
         }

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/UtilsTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/UtilsTest.java
@@ -176,7 +176,6 @@ public class UtilsTest {
         //EPStatement st = epService.getEPAdministrator().createEPL(epl, name);
 
         EPRuntime epService = EPRuntimeProvider.getDefaultRuntime(configuration);
-        //epService.initialize();
 
         EPDeployment deployment = Utils.compileDeploy(epService, epl, name);
         EPStatement st = deployment.getStatements()[0];
@@ -188,10 +187,9 @@ public class UtilsTest {
         //assertEquals(st.getText(), result.getString("text"));
         assertEquals(st.getProperty(StatementProperty.EPL).toString(), result.getString("text"));
         //assertEquals(st.getState(), result.get("state"));
-        // TBD: assertEquals(st.isDestroyed(), result.get("state"));
-        //assertEquals(st.getName(), result.getString("name"));
+        assertEquals(st.isDestroyed(), result.get("state"));
         //assertEquals(st.getTimeLastStateChange(), result.getLong("timeLastStateChange"));
-        assertEquals(epa.getDeployment(deployment.getDeploymentId()).getLastUpdateDate(), result.getLong("timeLastStateChange"));
+        assertEquals(epa.getDeployment(deployment.getDeploymentId()).getLastUpdateDate().getTime(), result.getLong("timeLastStateChange"));
     }
 
     /**

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/UtilsTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/UtilsTest.java
@@ -21,11 +21,31 @@ package com.telefonica.iot.perseo;
 
 import com.telefonica.iot.perseo.test.ServletContextMock;
 import com.telefonica.iot.perseo.test.EventBeanMock;
-import com.espertech.esper.client.ConfigurationOperations;
-import com.espertech.esper.client.EPServiceProvider;
-import com.espertech.esper.client.EPServiceProviderManager;
-import com.espertech.esper.client.EPStatement;
-import com.espertech.esper.client.EventBean;
+// import com.espertech.esper.client.ConfigurationOperations;
+import com.espertech.esper.common.client.configuration.Configuration;
+import com.espertech.esper.common.client.configuration.*;
+import com.espertech.esper.common.client.configuration.common.*;
+import com.espertech.esper.common.client.configuration.compiler.*;
+// import com.espertech.esper.client.EPServiceProvider;
+import com.espertech.esper.runtime.client.EPRuntime;
+// import com.espertech.esper.client.EPServiceProviderManager;
+import com.espertech.esper.runtime.client.EPRuntimeProvider;
+// import com.espertech.esper.client.EPStatement;
+import com.espertech.esper.runtime.client.EPStatement;
+// import com.espertech.esper.client.EventBean;
+import com.espertech.esper.common.client.EventBean;
+import com.espertech.esper.runtime.client.EPStatement;
+import com.espertech.esper.runtime.client.EPDeploymentService;
+import com.espertech.esper.runtime.client.EPDeployment;
+import com.espertech.esper.common.client.EPException;
+import com.espertech.esper.compiler.client.CompilerArguments;
+import com.espertech.esper.common.client.EPCompiled;
+import com.espertech.esper.compiler.client.EPCompilerProvider;
+import com.espertech.esper.compiler.client.EPCompileException;
+import com.espertech.esper.runtime.client.EPDeployException;
+import com.espertech.esper.runtime.client.EPUndeployException;
+import com.espertech.esper.common.client.util.StatementProperty;
+
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -80,10 +100,12 @@ public class UtilsTest {
     public void testInitEPService() {
         logger.info("initEPService");
         ServletContext sc = new ServletContextMock();
-        EPServiceProvider result = Utils.initEPService(sc);
+        //EPServiceProvider result = Utils.initEPService(sc);
+        EPRuntime result = Utils.initEPService(sc);
         assertEquals(sc.getAttribute("epService"), result);
         //Do not create a new one if it already exists
-        EPServiceProvider result2 = Utils.initEPService(sc);
+        //EPServiceProvider result2 = Utils.initEPService(sc);
+        EPRuntime result2 = Utils.initEPService(sc);
         assertEquals(result, result2);
     }
 
@@ -140,21 +162,49 @@ public class UtilsTest {
         final String epl = Help.ExampleRules()[1];
         final String name = "rule name";
         logger.info("Statement2JSONObject");
-        EPServiceProvider epService = EPServiceProviderManager.getDefaultProvider();
+        //EPServiceProvider epService = EPServiceProviderManager.getDefaultProvider();
+        EPRuntime epService = EPRuntimeProvider.getDefaultRuntime(configuration);
         Map<String, Object> def = new HashMap<String, Object>();
         def.put("id", String.class);
         def.put("type", String.class);
         def.put(Constants.SUBSERVICE_FIELD, String.class);
         def.put(Constants.SERVICE_FIELD, String.class);
-        ConfigurationOperations cfg = epService.getEPAdministrator().getConfiguration();
+        //ConfigurationOperations cfg = epService.getEPAdministrator().getConfiguration();
+        com.espertech.esper.common.client.configuration.Configuration cfgCopy = epService.getConfigurationDeepCopy();
+        ConfigurationCommon cfg = cfgCopy.getCommon();
         cfg.addEventType("iotEvent", def);
-        EPStatement st = epService.getEPAdministrator().createEPL(epl, name);
+        //EPStatement st = epService.getEPAdministrator().createEPL(epl, name);
+
+        // Deployment for compile newEPL
+        com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
+        CompilerArguments arguments = new CompilerArguments(configuration);
+        arguments.getPath().add(epService.getRuntimePath());
+        EPCompiled epCompiled = null;
+        try {
+            epCompiled = EPCompilerProvider.getCompiler().compile(epl, arguments);
+        } catch (EPCompileException ex) {
+            throw new RuntimeException(ex);
+        }
+        EPDeployment deploymentForEPL;
+        try {
+            deploymentForEPL = epa.deploy(epCompiled);
+        } catch (EPDeployException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        dId = deploymentForEPL.getDeploymentId();
+        EPStatement st = epa.getStatement(dId, ruleName);
+
+
         JSONObject result = Utils.Statement2JSONObject(st);
         assertEquals(st.getName(), result.getString("name"));
-        assertEquals(st.getText(), result.getString("text"));
-        assertEquals(st.getState(), result.get("state"));
-        assertEquals(st.getName(), result.getString("name"));
-        assertEquals(st.getTimeLastStateChange(), result.getLong("timeLastStateChange"));
+        //assertEquals(st.getText(), result.getString("text"));
+        assertEquals(st.getProperty(StatementProperty.EPL).toString(), result.getString("text"));
+        //assertEquals(st.getState(), result.get("state"));
+        assertEquals(st.isDestroyed(), result.get("state"));
+        //assertEquals(st.getName(), result.getString("name"));
+        //assertEquals(st.getTimeLastStateChange(), result.getLong("timeLastStateChange"));
+        assertEquals(epService.getDeployment(dId).getLastUpdateDate(), result.getLong("timeLastStateChange"));
     }
 
     /**

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/UtilsTest.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/UtilsTest.java
@@ -163,7 +163,9 @@ public class UtilsTest {
         final String name = "rule name";
         logger.info("Statement2JSONObject");
         //EPServiceProvider epService = EPServiceProviderManager.getDefaultProvider();
+        com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
         EPRuntime epService = EPRuntimeProvider.getDefaultRuntime(configuration);
+        epService.initialize();
         Map<String, Object> def = new HashMap<String, Object>();
         def.put("id", String.class);
         def.put("type", String.class);
@@ -175,8 +177,9 @@ public class UtilsTest {
         cfg.addEventType("iotEvent", def);
         //EPStatement st = epService.getEPAdministrator().createEPL(epl, name);
 
+        EPDeploymentService epa = epService.getDeploymentService();
+
         // Deployment for compile newEPL
-        com.espertech.esper.common.client.configuration.Configuration configuration = new com.espertech.esper.common.client.configuration.Configuration();
         CompilerArguments arguments = new CompilerArguments(configuration);
         arguments.getPath().add(epService.getRuntimePath());
         EPCompiled epCompiled = null;
@@ -192,8 +195,8 @@ public class UtilsTest {
             throw new RuntimeException(ex);
         }
 
-        dId = deploymentForEPL.getDeploymentId();
-        EPStatement st = epa.getStatement(dId, ruleName);
+        String dId = deploymentForEPL.getDeploymentId();
+        EPStatement st = epa.getStatement(dId, name);
 
 
         JSONObject result = Utils.Statement2JSONObject(st);
@@ -204,7 +207,7 @@ public class UtilsTest {
         assertEquals(st.isDestroyed(), result.get("state"));
         //assertEquals(st.getName(), result.getString("name"));
         //assertEquals(st.getTimeLastStateChange(), result.getLong("timeLastStateChange"));
-        assertEquals(epService.getDeployment(dId).getLastUpdateDate(), result.getLong("timeLastStateChange"));
+        assertEquals(epa.getDeployment(dId).getLastUpdateDate(), result.getLong("timeLastStateChange"));
     }
 
     /**

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -18,15 +18,23 @@
 */
 
 package com.telefonica.iot.perseo.test;
-
-import com.espertech.esper.client.EventBean;
-import com.espertech.esper.client.EventPropertyDescriptor;
-import com.espertech.esper.client.EventPropertyGetter;
-import com.espertech.esper.client.EventPropertyGetterIndexed;
-import com.espertech.esper.client.EventPropertyGetterMapped;
-import com.espertech.esper.client.EventType;
-import com.espertech.esper.client.FragmentEventType;
-import com.espertech.esper.client.PropertyAccessException;
+// import com.espertech.esper.client.EventBean;
+// import com.espertech.esper.client.EventPropertyDescriptor;
+// import com.espertech.esper.client.EventPropertyGetter;
+// import com.espertech.esper.client.EventPropertyGetterIndexed;
+// import com.espertech.esper.client.EventPropertyGetterMapped;
+// import com.espertech.esper.client.EventType;
+// import com.espertech.esper.client.FragmentEventType;
+// import com.espertech.esper.client.PropertyAccessException;
+import com.espertech.esper.common.client.EventBean;
+import com.espertech.esper.common.client.EventPropertyDescriptor;
+import com.espertech.esper.common.client.EventPropertyGetter;
+import com.espertech.esper.common.client.EventPropertyGetterIndexed;
+import com.espertech.esper.common.client.EventPropertyGetterMapped;
+import com.espertech.esper.common.client.EventTypeMetadata;
+import com.espertech.esper.common.client.EventType;
+import com.espertech.esper.common.client.FragmentEventType;
+import com.espertech.esper.common.client.PropertyAccessException;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -123,6 +131,12 @@ public class EventBeanMock implements EventBean {
         public String getEndTimestampPropertyName() {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
+
+        @Override
+        public EventTypeMetadata getMetadata() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
     };
 
     @Override

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -35,8 +35,8 @@ import com.espertech.esper.common.client.meta.EventTypeMetadata;
 import com.espertech.esper.common.client.EventType;
 import com.espertech.esper.common.client.FragmentEventType;
 import com.espertech.esper.common.client.PropertyAccessException;
-// import com.espertech.esper.common.client.type.EPTypeClass;
-// import com.espertech.esper.common.client.type.EPType;
+import com.espertech.esper.common.client.type.EPTypeClass;
+import com.espertech.esper.common.client.type.EPType;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -144,15 +144,15 @@ public class EventBeanMock implements EventBean {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
-        // @Override
-        // public EPTypeClass getUnderlyingEPType() {
-        //     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        // }
+        @Override
+        public EPTypeClass getUnderlyingEPType() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
 
-        // @Override
-        // public EPType getPropertyEPType(java.lang.String string) {
-        //     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        // }
+        @Override
+        public EPType getPropertyEPType(java.lang.String string) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
         };
 
     @Override

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -35,8 +35,8 @@ import com.espertech.esper.common.client.meta.EventTypeMetadata;
 import com.espertech.esper.common.client.EventType;
 import com.espertech.esper.common.client.FragmentEventType;
 import com.espertech.esper.common.client.PropertyAccessException;
-import com.espertech.esper.common.client.type.EPTypeClass;
-import com.espertech.esper.common.client.type.EPType;
+// import com.espertech.esper.common.client.type.EPTypeClass;
+// import com.espertech.esper.common.client.type.EPType;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -144,15 +144,15 @@ public class EventBeanMock implements EventBean {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
-        @Override
-        public EPTypeClass getUnderlyingEPType() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        }
+        // @Override
+        // public EPTypeClass getUnderlyingEPType() {
+        //     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        // }
 
-        @Override
-        public EPType getPropertyEPType(java.lang.String string) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        }
+        // @Override
+        // public EPType getPropertyEPType(java.lang.String string) {
+        //     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        // }
         };
 
     @Override

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -35,7 +35,7 @@ import com.espertech.esper.common.client.meta.EventTypeMetadata;
 import com.espertech.esper.common.client.EventType;
 import com.espertech.esper.common.client.FragmentEventType;
 import com.espertech.esper.common.client.PropertyAccessException;
-import com.espertech.esper.common.client.type.EPTypeClass:
+import com.espertech.esper.common.client.type.EPTypeClass;
 import java.util.Iterator;
 import java.util.Map;
 

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -35,6 +35,7 @@ import com.espertech.esper.common.client.meta.EventTypeMetadata;
 import com.espertech.esper.common.client.EventType;
 import com.espertech.esper.common.client.FragmentEventType;
 import com.espertech.esper.common.client.PropertyAccessException;
+import com.espertech.esper.common.client.type.EPTypeClass:
 import java.util.Iterator;
 import java.util.Map;
 
@@ -155,6 +156,10 @@ public class EventBeanMock implements EventBean {
 
     @Override
     public Object getUnderlying() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    public EPTypeClass getUnderlyingEPType() {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -150,7 +150,7 @@ public class EventBeanMock implements EventBean {
         }
 
         @Override
-        public EPType getPropertyEPType(java.lang.String)
+        public EPType getPropertyEPType(java.lang.String) {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
         };

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -36,6 +36,7 @@ import com.espertech.esper.common.client.EventType;
 import com.espertech.esper.common.client.FragmentEventType;
 import com.espertech.esper.common.client.PropertyAccessException;
 import com.espertech.esper.common.client.type.EPTypeClass;
+import com.espertech.esper.common.client.type.EPType;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -145,6 +146,11 @@ public class EventBeanMock implements EventBean {
 
         @Override
         public EPTypeClass getUnderlyingEPType() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public EPType getPropertyEPType(java.lang.String)
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
         };

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -150,7 +150,7 @@ public class EventBeanMock implements EventBean {
         }
 
         @Override
-        public EPType getPropertyEPType(java.lang.String) {
+        public EPType getPropertyEPType(java.lang.String string) {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
         };

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -31,7 +31,7 @@ import com.espertech.esper.common.client.EventPropertyDescriptor;
 import com.espertech.esper.common.client.EventPropertyGetter;
 import com.espertech.esper.common.client.EventPropertyGetterIndexed;
 import com.espertech.esper.common.client.EventPropertyGetterMapped;
-import com.espertech.esper.common.client.EventTypeMetadata;
+import com.espertech.esper.common.client.meta.EventTypeMetadata;
 import com.espertech.esper.common.client.EventType;
 import com.espertech.esper.common.client.FragmentEventType;
 import com.espertech.esper.common.client.PropertyAccessException;
@@ -117,10 +117,10 @@ public class EventBeanMock implements EventBean {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
-        @Override
-        public int getEventTypeId() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-        }
+        // @Override
+        // public int getEventTypeId() {
+        //     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        // }
 
         @Override
         public String getStartTimestampPropertyName() {
@@ -137,6 +137,10 @@ public class EventBeanMock implements EventBean {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
+        @Override
+        public java.util.Set<EventType> getDeepSuperTypesAsSet(){
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
     };
 
     @Override

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/EventBeanMock.java
@@ -142,7 +142,12 @@ public class EventBeanMock implements EventBean {
         public java.util.Set<EventType> getDeepSuperTypesAsSet(){
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
-    };
+
+        @Override
+        public EPTypeClass getUnderlyingEPType() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+        };
 
     @Override
     public EventType getEventType() {
@@ -159,9 +164,7 @@ public class EventBeanMock implements EventBean {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
-    public EPTypeClass getUnderlyingEPType() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
+
 
     @Override
     public Object getFragment(String string) throws PropertyAccessException {

--- a/perseo-main/src/test/java/com/telefonica/iot/perseo/test/Help.java
+++ b/perseo-main/src/test/java/com/telefonica/iot/perseo/test/Help.java
@@ -1,5 +1,5 @@
 /**
-* Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+* Copyright 2015 Telefonica InvestigaciÃ³n y Desarrollo, S.A.U
 *
 * This file is part of perseo-core project.
 *
@@ -45,10 +45,11 @@ public class Help {
     public static String[] ExampleRules() {
         return new String[]{
                  "select id, price? as Price from iotEvent.win:length(100) group by id",
-                    "@Audit select *,\"blood_1_action\" as iotcepaction,"
+                 "@Audit select *,\"blood_1_action\" as iotcepaction,"
                     + "ev.BloodPressure? as Pression, ev.id? as Meter from pattern "
-                    + "[every ev=iotEvent(cast(cast(BloodPressure?,String),float)>1.5"
-                    + " and type=\"BloodMeter\")]"};  
+                    + "[every ev=iotEvent(cast(cast(BloodPressure?,String),double)>1.5"
+                    + " and type=\"BloodMeter\")]"
+        };
     }
     public static String[] ExampleNotices() {
         return new String[]{
@@ -58,11 +59,11 @@ public class Help {
             + "\"otro\":\"mas\",\n"
             + "\"numero\":4,\n"
             + "\"sub\": {\n"
-            + "	\"subnumero\":18,\n"
-            + "	\"subcadena\":\"SUB2\",\n"
-            + "	\"subflotante\": 12.3,\n"
-            + "	\"sub2\": { \"valor\": 3}\n"
-            + "	}\n"
+            + " \"subnumero\":18,\n"
+            + " \"subcadena\":\"SUB2\",\n"
+            + " \"subflotante\": 12.3,\n"
+            + " \"sub2\": { \"valor\": 3}\n"
+            + " }\n"
             + "}"};
     }
            


### PR DESCRIPTION
We are using with Perseo  often this kind of casting 
    : ```cast(cast(BloodPressure?,String),float)>1.5```

But Esper 8.5+ is not allowing that:

![Screenshot from 2021-09-15 13-17-03](https://user-images.githubusercontent.com/983422/133423870-de4f66bf-4c1d-4827-9d1e-6d38605eab53.png)

- [ ] Ensure backward compatibility ?  (migrate all previous rules?)
