### PR TITLE
update pom.xml with missed jar: add missed dep: esper_common_avro

### DIFF
--- a/perseo-main/pom.xml
+++ b/perseo-main/pom.xml
@@ -82,6 +82,11 @@
             <version>8.4.0</version>
         </dependency>
         <dependency>
+            <groupId>com.espertech</groupId>
+            <artifactId>esper-common-avro</artifactId>
+            <version>8.4.0</version>
+        </dependency>
+        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>


### PR DESCRIPTION
Try fix the following message at perseo-core start up time

time=2022-02-24T10:59:23.292Z | lvl=DEBUG | from=172.17.0.12 | corr=n/a | trans=ee64fb97-27a5-417e-9359-01e6de2ee6be | srv=n/a | subsrv=n/a | op=resolve | comp=perseo-core | msg=Avro provider com.espertech.esper.common.internal.avro.core.EventTypeAvroHandlerImpl not instantiated, not enabling Avro support: Unable to load class 'com.espertech.esper.common.internal.avro.core.EventTypeAvroHandlerImpl', class not found


