### PR TITLE
Task/set internal timer resolution

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-ADD: unhardwire default internal timer msec resolution (millisecond resolution of the internal timer thread) with a default of 30ms (#194)
+ADD: unhardwire default internal timer msec resolution (millisecond resolution of the internal timer thread) with a default of 10ms (#194)
 ADD: INTERNAL_TIMER_MSEC_RESOLUTION env var for internal msec resolution (#194)
 FIX: Ensure timerules are stored with unique name by using full name which includes service and subservice (#191)
 FIX: upgrade docker based image from Tomcat8 to Tomcat9

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+ADD: Set default internal timer msec resolution (millisecond resolutuion of the internal timer thread) (#194)
 FIX: Ensure timerules are stored with unique name by using full name which includes service and subservice (#191)
 FIX: upgrade docker based image from Tomcat8 to Tomcat9
 FIX: migrate log4j v1 (1.7.25) to v2 (2.17.2) (#184)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
-ADD: Set default internal timer msec resolution (millisecond resolutuion of the internal timer thread) (#194)
+ADD: unhardwire default internal timer msec resolution (millisecond resolution of the internal timer thread) with a default of 30ms (#194)
+ADD: INTERNAL_TIMER_MSEC_RESOLUTION env var for internal msec resolution (#194)
 FIX: Ensure timerules are stored with unique name by using full name which includes service and subservice (#191)
 FIX: upgrade docker based image from Tomcat8 to Tomcat9
 FIX: migrate log4j v1 (1.7.25) to v2 (2.17.2) (#184)

--- a/documentation/config.md
+++ b/documentation/config.md
@@ -46,7 +46,7 @@ action.url = http://127.0.0.1:9090/actions/do
 rule.max_age= 60000
 
 # Length of the interval (resolution) of the timer thread
-internal_timer_msec_resolution = 30
+internal_timer_msec_resolution = 10
 ```
 
 The `action.url` field is the URL used to make a POST in the case of a rule being fired by an incoming event. The content POSTed is the JSON representation of the derived  ("complex") event.

--- a/documentation/config.md
+++ b/documentation/config.md
@@ -53,4 +53,4 @@ The `action.url` field is the URL used to make a POST in the case of a rule bein
 
 The `rule.max_age` field is the value in milliseconds used as a threshold for the age of a rule to deleted safely in case of a PUT request over the rules resource does not contain the rule. All the rules older than rule.max_age will be deleted if they are not in the new set. If a rule is younger than `rule.max_age` it will be kept despite not being in the set sent by the PUT request.
 
-The `internal_timer_msec_resolution` field is the value in milliseconds used for resolution of the internal timer thread
+The `internal_timer_msec_resolution` field is the value in milliseconds used for resolution of the internal timer thread. More detail in [esper](http://esper.espertech.com/release-8.4.0/javadoc-esper/com/espertech/esper/common/client/configuration/runtime/ConfigurationRuntimeThreading.html#setInternalTimerMsecResolution-long-)

--- a/documentation/config.md
+++ b/documentation/config.md
@@ -24,6 +24,13 @@ Example:
 MAX_AGE=6000
 ```
 
+INTERNAL_TIMER_MSEC_RESOLUTION is the millisecond resolutuion of the internal timer thread.
+
+Example:
+```
+INTERNAL_TIMER_MSEC_RESOLUTION=100
+```
+
 
 ### Configure Perseo-core with configuration file
 
@@ -37,9 +44,13 @@ action.url = http://127.0.0.1:9090/actions/do
 
 # Time in milliseconds (long) to "expire" a "dangling" rule
 rule.max_age= 60000
+
+# millisecond resolutuion of the internal timer thread
+internal_timer_msec_resolution = 30
 ```
 
 The `action.url` field is the URL used to make a POST in the case of a rule being fired by an incoming event. The content POSTed is the JSON representation of the derived  ("complex") event.
 
 The `rule.max_age` field is the value in milliseconds used as a threshold for the age of a rule to deleted safely in case of a PUT request over the rules resource does not contain the rule. All the rules older than rule.max_age will be deleted if they are not in the new set. If a rule is younger than `rule.max_age` it will be kept despite not being in the set sent by the PUT request.
 
+The `internal_timer_msec_resolution` field is the value in milliseconds used for resolutuion of the internal timer thread

--- a/documentation/config.md
+++ b/documentation/config.md
@@ -24,7 +24,7 @@ Example:
 MAX_AGE=6000
 ```
 
-INTERNAL_TIMER_MSEC_RESOLUTION is the millisecond resolutuion of the internal timer thread.
+INTERNAL_TIMER_MSEC_RESOLUTION is the length of the interval (resolution) of the timer thread.
 
 Example:
 ```
@@ -45,7 +45,7 @@ action.url = http://127.0.0.1:9090/actions/do
 # Time in milliseconds (long) to "expire" a "dangling" rule
 rule.max_age= 60000
 
-# millisecond resolutuion of the internal timer thread
+# Length of the interval (resolution) of the timer thread
 internal_timer_msec_resolution = 30
 ```
 
@@ -53,4 +53,4 @@ The `action.url` field is the URL used to make a POST in the case of a rule bein
 
 The `rule.max_age` field is the value in milliseconds used as a threshold for the age of a rule to deleted safely in case of a PUT request over the rules resource does not contain the rule. All the rules older than rule.max_age will be deleted if they are not in the new set. If a rule is younger than `rule.max_age` it will be kept despite not being in the set sent by the PUT request.
 
-The `internal_timer_msec_resolution` field is the value in milliseconds used for resolution of the internal timer thread. More detail in [esper](http://esper.espertech.com/release-8.4.0/javadoc-esper/com/espertech/esper/common/client/configuration/runtime/ConfigurationRuntimeThreading.html#setInternalTimerMsecResolution-long-)
+The `internal_timer_msec_resolution` Length of the interval (resolution) of the timer thread. More detail in [esper](http://esper.espertech.com/release-8.4.0/javadoc-esper/com/espertech/esper/common/client/configuration/runtime/ConfigurationRuntimeThreading.html#setInternalTimerMsecResolution-long-)

--- a/documentation/config.md
+++ b/documentation/config.md
@@ -53,4 +53,4 @@ The `action.url` field is the URL used to make a POST in the case of a rule bein
 
 The `rule.max_age` field is the value in milliseconds used as a threshold for the age of a rule to deleted safely in case of a PUT request over the rules resource does not contain the rule. All the rules older than rule.max_age will be deleted if they are not in the new set. If a rule is younger than `rule.max_age` it will be kept despite not being in the set sent by the PUT request.
 
-The `internal_timer_msec_resolution` field is the value in milliseconds used for resolutuion of the internal timer thread
+The `internal_timer_msec_resolution` field is the value in milliseconds used for resolution of the internal timer thread

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Configuration.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Configuration.java
@@ -42,7 +42,7 @@ public final class Configuration {
 
     private static final String DEFAULT_PERSEO_FE_URL = "http://127.0.0.1:9090";
     private static final long DEFAULT_MAX_AGE = 60000;
-    private static final long DEFAULT_INTERNAL_TIMER_MSEC_RESOLUTION = 30;
+    private static final long DEFAULT_INTERNAL_TIMER_MSEC_RESOLUTION = 10;
 
     private static final String PERSEO_FE_URL_ENV = "PERSEO_FE_URL";
     private static final String PERSEO_MAX_AGE_ENV = "MAX_AGE";

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Configuration.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Configuration.java
@@ -46,13 +46,13 @@ public final class Configuration {
 
     private static final String PERSEO_FE_URL_ENV = "PERSEO_FE_URL";
     private static final String PERSEO_MAX_AGE_ENV = "MAX_AGE";
-    private static final String PERSEO_INTERNAL_TIMER_MSEC_RESOLUTION;
+    private static final String PERSEO_INTERNAL_TIMER_MSEC_RESOLUTION_ENV = "INTERNAL_TIMER_MSEC_RESOLUTION";
 
     private static final Properties PROPERTIES = new Properties();
     private static final String PATH = "/etc/perseo-core.properties";
     private static final String ACTION_URL_PROP = "action.url";
     private static final String MAX_AGE_PROP = "rule.max_age";
-    private static final String INTERNAL_TIMER_MSEC_RESOLUTION = "internal_msec_resolution";
+    private static final String INTERNAL_TIMER_MSEC_RESOLUTION = "internal_timer_msec_resolution";
 
     private static String actionRule;
     private static long maxAge;
@@ -121,12 +121,12 @@ public final class Configuration {
         LOGGER.info(String.format("maxAge configuration is: %s",maxAge));
 
         // Get INTERNAL_TIMER_MSEC_RESOLUTION from env var if exist, else default
-        String internalTimerMsecResolutionEnv = System.getenv(PERSEO_INTERNAL_TIMER_MSEC_RESOLUTION);
+        String internalTimerMsecResolutionEnv = System.getenv(PERSEO_INTERNAL_TIMER_MSEC_RESOLUTION_ENV);
         // Check maxAge numerical value
         try {
             internalTimerMsecResolution = internalTimerMsecResolutionEnv != null ? Long.parseLong(internalTimerMsecResolutionEnv) : Long.parseLong(defaultInternalTimerMsecResolution);
         } catch (NumberFormatException nfe) {
-            LOGGER.error(String.format("Invalid value for %s: %s",PERSEO_INTERNAL_TIMER_MSEC_RESOLUTION,nfe));
+            LOGGER.error(String.format("Invalid value for %s: %s",PERSEO_INTERNAL_TIMER_MSEC_RESOLUTION_ENV,nfe));
             return false;
         }
         LOGGER.info(String.format("internalTimerMsecResolution configuration is: %s",internalTimerMsecResolution));
@@ -152,6 +152,10 @@ public final class Configuration {
         return maxAge;
     }
 
+    /**
+     *
+     * @return millisecond resolutuion of the internal timer thread
+     */
     public static synchronized long getInternalTimerMsecResolution() {
         return internalTimerMsecResolution;
     }

--- a/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
+++ b/perseo-main/src/main/java/com/telefonica/iot/perseo/Utils.java
@@ -78,6 +78,7 @@ public class Utils {
         configuration.getCompiler().getByteCode().setAllowSubscriber(true);
         configuration.getCompiler().getByteCode().setAccessModifiersPublic();
         configuration.getCompiler().getByteCode().setBusModifierEventType(EventTypeBusModifier.BUS);
+        configuration.getRuntime().getThreading().setInternalTimerMsecResolution(com.telefonica.iot.perseo.Configuration.getInternalTimerMsecResolution());
         EPRuntime epService = (EPRuntime) sc.getAttribute(EPSERV_ATTR_NAME);
         if (epService == null) {
 


### PR DESCRIPTION

http://esper.espertech.com/release-8.4.0/javadoc-esper/com/espertech/esper/common/client/configuration/runtime/ConfigurationRuntimeThreading.html#setInternalTimerMsecResolution-long-

With this PR default value for internal timer resolution will be 30

https://github.com/telefonicaid/perseo-core/issues/194