### PR TITLE
Task/add perseo log level env

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Switch log level to PERSEO_LOG_LEVEL env var if was provided to docker (#178)

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -115,7 +115,7 @@ from the root directory of the project.
 In order to undeploy the proxy just remove the .war and the directoryin webapps/.
 
 
-### Log Rotation
+### Log Rotation (not apply to Docker container)
 Independently of how the service is installed, the log files will need an external rotation (e.g.: the logrotate command) to avoid disk full problems.
 
 Logrotate is installed as RPM dependency along with perseo. The system is configured to rotate every day and whenever the log file size is greater than 100MB (checked very 30 minutes by default):

--- a/documentation/logs.md
+++ b/documentation/logs.md
@@ -1,6 +1,6 @@
 # Logs
 
-Logs have levels `FATAL`, `ERROR`, `INFO` and `DEBUG`. The log level must be set in the configuration file `log4j.xml`
+Logs have levels `FATAL`, `ERROR`, `WARN`, `INFO` and `DEBUG`. The log level must be set in the configuration file `log4j.xml`
 
 ```xml
         <priority value="info" />
@@ -29,6 +29,10 @@ The log level can be changed at run-time, with an HTTP PUT request
 ```
  curl --request PUT <host>:<port>/perseo-core/admin/log?level=<FATAL|ERROR|WARNING|WARN|INFO|DEBUG>
  ```
+
+# LogLevel of Docker container
+
+There is an environmente variable named `PERSEO_LOG_LEVEL` which could be used to provide container a log level to switch after docker starts. The possible values for that variable could be `FATAL`, `ERROR`, `WARNING`, `WARN`, `INFO` and `DEBUG`.
 
 # Alarms
 

--- a/perseo_core-entrypoint.sh
+++ b/perseo_core-entrypoint.sh
@@ -30,6 +30,10 @@ touch /var/log/perseo/perseo-core.log
 
 ln -snf /dev/stdout /var/log/perseo/perseo-core.log &
 
+if [ "$PERSEO_LOG_LEVEL" ]; then
+    (sleep 10; curl -X PUT 'http://localhost:8080/perseo-core/admin/log?level=$PERSEO_LOG_LEVEL') &
+fi
+
 # We use tomcat from Apache, then will be started using catalina.sh, instead service tomcat
 
 exec ${CATALINA_HOME}/bin/catalina.sh run

--- a/perseo_core-entrypoint.sh
+++ b/perseo_core-entrypoint.sh
@@ -31,7 +31,7 @@ touch /var/log/perseo/perseo-core.log
 ln -snf /dev/stdout /var/log/perseo/perseo-core.log &
 
 if [ "$PERSEO_LOG_LEVEL" ]; then
-    (sleep 10; curl -X PUT 'http://localhost:8080/perseo-core/admin/log?level=$PERSEO_LOG_LEVEL') &
+    (sleep 10; curl -X PUT 'http://localhost:8080/perseo-core/admin/log?level='$PERSEO_LOG_LEVEL) &
 fi
 
 # We use tomcat from Apache, then will be started using catalina.sh, instead service tomcat


### PR DESCRIPTION

fix for https://github.com/telefonicaid/perseo-core/issues/178


  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     011-May-2022 13:00:40.537 INFO [main] org.apache.catalina.startup.HostConfig.deployWAR Deployment of web application archive [/usr/local/tomcat/webapps/perseo-core.war] has finished in [15,015] ms
11-May-2022 13:00:40.563 INFO [main] org.apache.coyote.AbstractProtocol.start Starting ProtocolHandler ["http-nio-8080"]
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     011-May-2022 13:00:40.740 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in [14678] milliseconds
time=2022-05-11T13:00:41.267Z | lvl=INFO | from= | corr= | trans= | srv= | subsrv= | op=doPut | comp=perseo-core | msg=changing log level to INFO
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
time=2022-05-11T13:00:43.815Z | lvl=INFO | from=172.17.0.14 | corr=n/a | trans=248f1188-89b6-4f68-8c20-7ccb48c77477 | srv=n/a | subsrv=n/a | op=updateAll | comp=perseo-core | msg=put rules+contexts: 10
