### PR TITLE
FIX remove Java<11 from GitActions test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
     strategy:
       matrix:
         java-version:
-          - 8
-          - 9
-          - 10
           - 11
           - 12
           - 13


### PR DESCRIPTION
As in Dockerfile we are using Java 11, it makes little sense to keep those older versions.